### PR TITLE
Updating Jet modulefiles (wgrib2)

### DIFF
--- a/modulefiles/modulefile.gplot.jet
+++ b/modulefiles/modulefile.gplot.jet
@@ -25,7 +25,8 @@ ulimit -c 0
 module purge
 module load intel/2022.1.2
 module load wgrib/1.8.1.0b
-module load wgrib2/2.0.8
+module load gnu/9.2.0
+module load wgrib2/3.1.1_ncep
 if [ "${A}" -eq 0 ]; then
     module load netcdf/4.6.1
     module load hdf5/1.10.4

--- a/modulefiles/modulefile.gplot.jettcsh
+++ b/modulefiles/modulefile.gplot.jettcsh
@@ -31,7 +31,8 @@ limit core 0
 module purge
 module load intel/2022.1.2
 module load wgrib/1.8.1.0b
-module load wgrib2/2.0.8
+module load gnu/9.2.0
+module load wgrib2/3.1.1_ncep
 if ( "${A}" == "0" ) then
     module load netcdf/4.6.1
     module load hdf5/1.10.4


### PR DESCRIPTION
## Description of changes
Updating Jet modulefiles to include wgrib2/3.1.1_ncep because wgrib2/2.0.8 will soon be deprecated. NCL and Python are both running with the updated module list.

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests. What platform(s) were used for testing?

- [x] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS2
