### PR TITLE
Fix for GPLOT SHIPS module to not pivot the longitude array because t…

### DIFF
--- a/sorc/GPLOT/ncl/GPLOT_ships.ncl
+++ b/sorc/GPLOT/ncl/GPLOT_ships.ncl
@@ -708,6 +708,7 @@ do fff = 0,nFiles-1
 		; Only need to do this once
 		if(ppp2.eq.0)then
 		do ddd = 0,nDims-1
+			BOCO@doPivot = False
 			; LATITUDE
 			if(isStrSubset(dNames(ddd),"lat"))then
 				lat := get_dim_lat(f,dNames(ddd),BOCO,tcLats,tcLons,fff,B)


### PR DESCRIPTION
…he data and coordinates are storm-centric.

## Description of changes
This PR is a simple fix to the GPLOT SHIPS module for a bug that incorrectly attempted to pivot the longitude coordinate array for limited-area storm-centric model data. The fix includes a simple addition - `BOCO@lonPivot = False`

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes #52 

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests. What platform(s) were used for testing?
Test command:
` ncl 'IDATE="2023041318"' 'SID="18S"' 'DOMAIN="ships"' 'TIER="Tier1"' 'ENSID=""' 'FORCE="False"' 'MASTER_NML_IN="/home/Ghassan.Alaka/GPLOT/parm/namelist.master.HWRF_Forecast"' /lfs1/HFIP/hur-aoml/Ghassan.Alaka/GPLOT_BRANCHES/hotfix/ships_failure_202304/sorc/GPLOT/ncl/GPLOT_ships.ncl`

- [x] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS2
