### PR TITLE
Merge `feature/slurm settings` into `develop`

### DIFF
--- a/sorc/GPLOT/batch/batch_airsea.sh
+++ b/sorc/GPLOT/batch/batch_airsea.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
+##SBATCH --nodes=1
+#SBATCH --ntasks=1
 #SBATCH --time=00:59:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -9,7 +10,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=128G
 
 set -x
 

--- a/sorc/GPLOT/batch/batch_maps.sh
+++ b/sorc/GPLOT/batch/batch_maps.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
+##SBATCH --nodes=1
 ##SBATCH --ntasks-per-node=12
+#SBATCH --ntasks=1
 #SBATCH --time=00:59:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=32G
 
 set -x
 

--- a/sorc/GPLOT/batch/batch_ocean_maps.sh
+++ b/sorc/GPLOT/batch/batch_ocean_maps.sh
@@ -1,7 +1,8 @@
 #!/bin/sh -x
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
+##SBATCH --nodes=1
 ##SBATCH --ntasks-per-node=12
+#SBATCH --ntasks=1
 #SBATCH --time=00:59:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=32G
 
 set -x
 

--- a/sorc/GPLOT/batch/batch_polar.sh
+++ b/sorc/GPLOT/batch/batch_polar.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
+##SBATCH --nodes=1
 ##SBATCH --ntasks-per-node=12
+#SBATCH --ntasks=1
 #SBATCH --time=00:59:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=64G
 
 set -x
 

--- a/sorc/GPLOT/batch/batch_ships.sh
+++ b/sorc/GPLOT/batch/batch_ships.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
+##SBATCH --nodes=1
 ##SBATCH --ntasks-per-node=12
+#SBATCH --ntasks=1
 #SBATCH --time=00:59:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=48G
 
 set -x
 

--- a/sorc/GPLOT/batch/spawn_airsea.sh
+++ b/sorc/GPLOT/batch/spawn_airsea.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
+##SBATCH --nodes=1
+##SBATCH --ntasks-per-node=1
+#SBATCH --ntasks=1
 #SBATCH --time=00:15:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=1G
 
 
 #set -x
@@ -999,7 +1000,7 @@ if [ "${DO_AIRSEA}" = "True" ]; then
                                 ${FULL_CMD} &
                             else
                                 SLRM_OPTS="--account=${CPU_ACCT} --job-name=${JOB_NAME} --output=${LOGFILE2} --error=${LOGFILE2}"
-                                SLRM_OPTS="${SLRM_OPTS} --nodes=1 --mem=128G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
+                                SLRM_OPTS="${SLRM_OPTS} --ntasks=1 --mem=128G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
                                 echo "MSG: Executing this command [${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}]."
                                 ${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}
                             fi

--- a/sorc/GPLOT/batch/spawn_maps.sh
+++ b/sorc/GPLOT/batch/spawn_maps.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
+##SBATCH --nodes=1
+##SBATCH --ntasks-per-node=1
+#SBATCH --ntasks=1
 #SBATCH --time=00:19:30
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=1G
 
 
 #set -x
@@ -1079,7 +1080,7 @@ if [ "${DO_MAPS}" = "True" ]; then
                             else
                                 SLRM_OPTS="--account=${CPU_ACCT} --job-name=${JOB_NAME} --output=${LOGFILE2} --error=${LOGFILE2}"
                                 #SLRM_OPTS="${SLRM_OPTS} --nodes=1 --ntasks-per-node=12 --mem=32G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
-                                SLRM_OPTS="${SLRM_OPTS} --nodes=1 --mem=32G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
+                                SLRM_OPTS="${SLRM_OPTS} --ntasks=1 --mem=32G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
                                 echo "MSG: Executing this command [${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}]."
                                 ${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}
                             fi

--- a/sorc/GPLOT/batch/spawn_ocean_maps.sh
+++ b/sorc/GPLOT/batch/spawn_ocean_maps.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
+##SBATCH --nodes=1
+##SBATCH --ntasks-per-node=1
+#SBATCH --ntasks=1
 #SBATCH --time=00:15:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=1G
 
 
 #set -x
@@ -1071,7 +1072,7 @@ if [ "${DO_OCEAN_MAPS}" = "True" ]; then
                             else
                                 SLRM_OPTS="--account=${CPU_ACCT} --job-name=${JOB_NAME} --output=${LOGFILE2} --error=${LOGFILE2}"
                                 #SLRM_OPTS="${SLRM_OPTS} --nodes=1 --ntasks-per-node=12 --mem=32G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
-                                SLRM_OPTS="${SLRM_OPTS} --nodes=1 --mem=32G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
+                                SLRM_OPTS="${SLRM_OPTS} --ntasks=1 --mem=32G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
                                 echo "MSG: Executing this command [${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}]."
                                 ${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}
                             fi

--- a/sorc/GPLOT/batch/spawn_polar.sh
+++ b/sorc/GPLOT/batch/spawn_polar.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
+##SBATCH --nodes=1
+##SBATCH --ntasks-per-node=1
+#SBATCH --ntasks=1
 #SBATCH --time=00:15:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=1G
 
 
 #set -x
@@ -996,7 +997,7 @@ if [ "${DO_POLAR}" = "True" ]; then
                             else
                                 SLRM_OPTS="--account=${CPU_ACCT} --job-name=${JOB_NAME} --output=${LOGFILE2} --error=${LOGFILE2}"
                                 #SLRM_OPTS="${SLRM_OPTS} --nodes=1 --ntasks-per-node=12 --mem=64G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
-                                SLRM_OPTS="${SLRM_OPTS} --nodes=1 --mem=64G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
+                                SLRM_OPTS="${SLRM_OPTS} --ntasks=1 --mem=64G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
                                 echo "MSG: Executing this command [${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}]."
                                 ${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}
                             fi

--- a/sorc/GPLOT/batch/spawn_ships.sh
+++ b/sorc/GPLOT/batch/spawn_ships.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
+##SBATCH --nodes=1
+##SBATCH --ntasks-per-node=1
+#SBATCH --ntasks=1
 #SBATCH --time=00:15:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=1G
 
 
 #set -x
@@ -1006,7 +1007,7 @@ if [ "${DO_SHIPS}" = "True" ]; then
                             else
                                 SLRM_OPTS="--account=${CPU_ACCT} --job-name=${JOB_NAME} --output=${LOGFILE2} --error=${LOGFILE2}"
                                 #SLRM_OPTS="${SLRM_OPTS} --nodes=1 --ntasks-per-node=12 --mem=48G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
-                                SLRM_OPTS="${SLRM_OPTS} --nodes=1 --mem=48G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
+                                SLRM_OPTS="${SLRM_OPTS} --ntasks=1 --mem=48G --time=${RUNTIME} --qos=${QOS} --partition=${PARTITION}"
                                 echo "MSG: Executing this command [${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}]."
                                 ${X_SBATCH} ${SLRM_OPTS} ${FULL_CMD}
                             fi

--- a/sorc/GPLOT/batch/spawn_stats.sh
+++ b/sorc/GPLOT/batch/spawn_stats.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 #SBATCH --account=hur-aoml
-#SBATCH --nodes=1
-#SBATCH --ntasks-per-node=1
+##SBATCH --nodes=1
+##SBATCH --ntasks-per-node=1
+#SBATCH --ntasks=1
 #SBATCH --time=00:15:00
 #SBATCH --partition=tjet,ujet,sjet,vjet,xjet,kjet
 #SBATCH --mail-type=FAIL
@@ -10,7 +11,7 @@
 #SBATCH --output=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.out
 #SBATCH --error=/lfs1/projects/hur-aoml/Ghassan.Alaka/GPLOT/log/GPLOT.Default.err
 #SBATCH --job-name="GPLOT.Default"
-#SBATCH --mem=16G
+#SBATCH --mem=1G
 
 
 #set -x

--- a/sorc/GPLOT/python/polar_cylindrical_structure.py
+++ b/sorc/GPLOT/python/polar_cylindrical_structure.py
@@ -1923,6 +1923,7 @@ def main():
       fig1.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig1.clf()
       plt.close(fig1)
 
 
@@ -1944,6 +1945,7 @@ def main():
       fig2.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig2.clf()
       plt.close(fig2)
 
 
@@ -1965,6 +1967,7 @@ def main():
       fig3.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig3.clf()
       plt.close(fig3)
 
 
@@ -1986,6 +1989,7 @@ def main():
       fig4.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig4.clf()
       plt.close(fig4)
 
 
@@ -2007,6 +2011,7 @@ def main():
       fig5.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig5.clf()
       plt.close(fig5)
 
 
@@ -2032,6 +2037,7 @@ def main():
       fig6.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig6.clf()
       plt.close(fig6)
 
 
@@ -2056,6 +2062,7 @@ def main():
       fig7.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig7.clf()
       plt.close(fig7)
 
 
@@ -2081,6 +2088,7 @@ def main():
       fig8.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig8.clf()
       plt.close(fig8)
 
 
@@ -2106,6 +2114,7 @@ def main():
       fig9.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig9.clf()
       plt.close(fig9)
 
 
@@ -2131,6 +2140,7 @@ def main():
       fig10.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig10.clf()
       plt.close(fig10)
 
 
@@ -2156,6 +2166,7 @@ def main():
       fig11.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig11.clf()
       plt.close(fig11)
 
 
@@ -2181,6 +2192,7 @@ def main():
       fig12.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig12.clf()
       plt.close(fig12)
 
 
@@ -2206,6 +2218,7 @@ def main():
       fig13.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig13.clf()
       plt.close(fig13)
 
 
@@ -2269,6 +2282,7 @@ def main():
       figfname = f'{ODIR}/{LONGSID.lower()}.dbz5km_wavenumber.{forecastinit}.polar.f{FHR:03}'
       #fig14.tight_layout()
       fig14.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
+      fig14.clf()
       plt.close(fig14)
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
@@ -2333,6 +2347,7 @@ def main():
       # Finalize figure
       figfname = f'{ODIR}/{LONGSID.lower()}.rh5km_wavenumber.{forecastinit}.polar.f{FHR:03}'
       fig15.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
+      fig15.clf()
       plt.close(fig15)
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
@@ -2397,6 +2412,7 @@ def main():
       # Finalize figure
       figfname = f'{ODIR}/{LONGSID.lower()}.vt10_wavenumber.{forecastinit}.polar.f{FHR:03}'
       fig16.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
+      fig16.clf()
       plt.close(fig16)      
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
@@ -2423,6 +2439,7 @@ def main():
       fig17.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig17.clf()
       plt.close(fig17)
 
       # Mean Vertical Advection
@@ -2443,6 +2460,7 @@ def main():
       fig18.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig18.clf()
       plt.close(fig18)
 
       # Mean Eddy Flux
@@ -2463,6 +2481,7 @@ def main():
       fig19.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig19.clf()
       plt.close(fig19)
 
       # Mean Vertical Eddy Advection
@@ -2483,6 +2502,7 @@ def main():
       fig20.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig20.clf()
       plt.close(fig20)
 
       # Sum of Mean Tendency Terms
@@ -2503,6 +2523,7 @@ def main():
       fig21.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig21.clf()
       plt.close(fig21)
 
     # FIGURES 22-26: Vorticity Tendency Terms
@@ -2526,6 +2547,8 @@ def main():
       fig22.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig22.clf()
+      plt.close(fig22)
 
       # Mean Vertical Advection
       fig23 = plt.figure(figsize=(20.5,10.5))
@@ -2545,6 +2568,7 @@ def main():
       fig23.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig23.clf()
       plt.close(fig23)
 
       # Mean Stretching COnvergence
@@ -2565,6 +2589,7 @@ def main():
       fig24.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig24.clf()
       plt.close(fig24)
 
       # Mean Tilting
@@ -2585,6 +2610,7 @@ def main():
       fig25.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig25.clf()
       plt.close(fig25)
 
       # Sum of Mean Tendency Terms
@@ -2605,6 +2631,7 @@ def main():
       fig26.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig26.clf()
       plt.close(fig26)
 
     if ( do_ur_pbl_p_mean == 'Y'):
@@ -2628,6 +2655,7 @@ def main():
       fig27.savefig(figfname+figext, bbox_inches='tight', dpi='figure')
       if DO_CONVERTGIF:
         os.system(f'convert {figfname}{figext} +repage gif:{figfname}.gif && /bin/rm {figfname}{figext}')
+      fig27.clf()
       plt.close(fig27)
   
     if ( do_radar_plots == 'Y'):  

--- a/sorc/GPLOT/scripts/GPLOT_wrapper.sh
+++ b/sorc/GPLOT/scripts/GPLOT_wrapper.sh
@@ -216,6 +216,7 @@ for NML in "${NML_LIST[@]}"; do
             else
                 SLRM_OPTS="--job-name=${JOBNAME}  --output=${SPAWNLOG2} --error=${SPAWNLOG2}"
                 SLRM_OPTS="${SLRM_OPTS} --account=${CPU_ACCT} --partition=${PARTITION} --qos=${QOS}"
+                SLRM_OPTS="${SLRM_OPTS} --ntasks=1 --mem=1G"
                 ${X_SBATCH} ${SLRM_OPTS} ${SPAWNFILE} ${NML}
             fi
         elif [ "${BATCH_MODE^^}" == "FOREGROUND" ]; then


### PR DESCRIPTION
## Description of changes
This PR merges in Slurm configuration improvements that were tested and committed to the `feature/slurm_settings` branch. All changes are focused on updating Slurm requests to request only a single task (`--ntasks=1`) and to use the memory request (`--mem=1G`). This combination of configuration options invokes Slurm to request the appropriate number of CPUs that are required to fulfill the memory request. It does not need to use the entire node, which is what happened when`--nodes=1` was requested instead.

## Issues addressed
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes https://github.com/ghassan-alaka/GPLOT/issues/65

## Contributors (optional)
N/A

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests. What platform(s) were used for testing?

- [x] Jet
- [x] Hera
- [ ] Orion
- [ ] WCOSS2
